### PR TITLE
Adds CURLOPT_CONNECTTIMEOUT to cURL options

### DIFF
--- a/lib/MobileCommons/Request.php
+++ b/lib/MobileCommons/Request.php
@@ -118,6 +118,7 @@ class Request
           CURLOPT_RETURNTRANSFER => 1,
           CURLOPT_URL => $requestUrl,
           CURLOPT_TIMEOUT => 30,
+          CURLOPT_CONNECTTIMEOUT => 30,
           CURLOPT_HTTPHEADER => array('Accept: application/xml'),
         );
 


### PR DESCRIPTION
Fixes #9 

Adds `CURLOPT_CONNECTTIMEOUT => 30` to `$curl_options` to force timeout. Currently connections appear to occasionally "hang".

**Reference**:
- http://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html