### PR TITLE
Use error response from cURL call

### DIFF
--- a/lib/MobileCommons/Request.php
+++ b/lib/MobileCommons/Request.php
@@ -131,8 +131,9 @@ class Request
         $curl_info = curl_getinfo($curl);
 
         //@todo test for curl error
-        if ($response === FALSE) {
-            throw new Exception(curl_error($curl), curl_errno($curl));
+        if ($errno = curl_errno($curl)) {
+          $error_message = $errno . ': ' . curl_strerror($errno);
+          throw new Exception($error_message);
         }
         curl_close($curl);
 

--- a/lib/MobileCommons/Request.php
+++ b/lib/MobileCommons/Request.php
@@ -133,7 +133,7 @@ class Request
         //@todo test for curl error
         if ($errno = curl_errno($curl)) {
           $error_message = $errno . ': ' . curl_strerror($errno);
-          throw new Exception($error_message);
+          throw new Exception($error_message, $errno);
         }
         curl_close($curl);
 

--- a/lib/MobileCommons/Request.php
+++ b/lib/MobileCommons/Request.php
@@ -184,7 +184,7 @@ class Request
         );
  
         $context = stream_context_create($opts);
-        return file_get_contents($url, FALSE, $context);
+        return file_get_contents($url, false, $context);
     }
  
 }


### PR DESCRIPTION
Fixes #12 

Uses return value from`curl_errno($curl)` to determine if cURL call resulted in error response. Replaces `$response === FALSE` as a `false` response may be a valid response.
